### PR TITLE
[t-h8XErwgE] - fix: Corrigido Icons quebrando no componente Stack icons

### DIFF
--- a/src/components/pages/CarrerPage/CarrerInfoSection/CarrerInfoSection.js
+++ b/src/components/pages/CarrerPage/CarrerInfoSection/CarrerInfoSection.js
@@ -16,7 +16,7 @@ export default CarrerInfoSection;
 
 const Root = styled.div`
   width: 40%;
-  height: 500px;
+  min-height: 500px;
 
   display: flex;
   flex-direction: column;

--- a/src/components/pages/CarrerPage/CarrerInfoSection/IconsForStack/IconsDiv.js
+++ b/src/components/pages/CarrerPage/CarrerInfoSection/IconsForStack/IconsDiv.js
@@ -57,6 +57,9 @@ const Root = styled.div`
 
 const BaseIconSvg = styled.img`
     width: 40px;
-    margin: 10px;
-    margin-bottom: 10px;
+    margin: 0 auto;
+    margin-bottom: 15px;
+    @media (max-width: 500px) {
+      width: 30px;
+    }
 `

--- a/src/components/pages/CarrerPage/CarrerInfoSection/IconsForStack/IconsForStack.js
+++ b/src/components/pages/CarrerPage/CarrerInfoSection/IconsForStack/IconsForStack.js
@@ -26,7 +26,7 @@ export default IconsForStack;
 const Root = styled.div`
   display: grid;
   grid-template-columns: 1fr 1fr;
-  height: 200px;
+  min-height: 200px;
 
   @media (max-width: 320px) {
     height: 400px;


### PR DESCRIPTION
- alterado o campo `height` para `min-height` em componentes que não quebravam quando um componente interno aumentava de tamanho.
- Adicionado media query no componente `<IconsDiv />` para que o tamanho dos ícones adequem ao mobile